### PR TITLE
Add success, failure for one-time exposure of result

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ repositories {
 }
 
 dependencies {
-    compile 'com.github.kittinunf.result:result:0.31'
+    compile 'com.github.kittinunf.result:result:0.4'
 }
 
 ```
@@ -52,7 +52,15 @@ val error = result.error
 val value: Int = result.get<Int>() ?: 0
 val ex: Exception = result.get<Exception>()!!
 
-//fold
+//success
+result.success {
+}
+
+//failure
+result.failure {
+}
+
+//fold is there, if you want to handle both success and failure
 result.fold({ value ->
     //do something with value
 }, { error ->

--- a/result/build.gradle
+++ b/result/build.gradle
@@ -10,7 +10,6 @@ dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 
     testCompile "junit:junit:$junit_version"
-    testCompile "org.jetbrains.kotlin:kotlin-test:$kotlin_version"
 }
 
 buildscript {
@@ -36,7 +35,7 @@ publish {
     artifactId = 'result'
     desc = 'The modelling for success/failure of operations in Kotlin'
     groupId = 'com.github.kittinunf.result'
-    publishVersion = '0.31'
+    publishVersion = '0.4'
     uploadName = 'Result'
     website = 'https://github.com/kittinunf/Result'
 }

--- a/result/src/main/kotlin/com/github/kittinunf/result/NoException.kt
+++ b/result/src/main/kotlin/com/github/kittinunf/result/NoException.kt
@@ -1,7 +1,3 @@
 package com.github.kittinunf.result
 
-/**
- * Created by Kittinun Vantasin on 10/30/15.
- */
-
 public class NoException private constructor() : Exception()

--- a/result/src/main/kotlin/com/github/kittinunf/result/Result.kt
+++ b/result/src/main/kotlin/com/github/kittinunf/result/Result.kt
@@ -1,27 +1,13 @@
 package com.github.kittinunf.result
 
-/**
- * Created by Kittinun Vantasin on 10/26/15.
- */
-
 public inline fun <reified X> Result<*, *>.getAs() = when (this) {
     is Result.Success -> value as? X
     is Result.Failure -> error as? X
 }
 
-public inline fun <V : Any> Result<V, *>.success(f: (V) -> Unit) {
-    when (this) {
-        is Result.Success -> f(value)
-        is Result.Failure -> {}
-    }
-}
+public fun <V : Any> Result<V, *>.success(f: (V) -> Unit) = fold(f, {})
 
-public inline fun <E : Exception> Result<*, E>.failure(f: (E) -> Unit) {
-    when (this) {
-        is Result.Success -> {}
-        is Result.Failure -> f(error)
-    }
-}
+public fun <E : Exception> Result<*, E>.failure(f: (E) -> Unit) = fold({}, f)
 
 public infix fun <V : Any, E : Exception> Result<V, E>.or(fallback: V) = when (this) {
     is Result.Success -> this

--- a/result/src/main/kotlin/com/github/kittinunf/result/Result.kt
+++ b/result/src/main/kotlin/com/github/kittinunf/result/Result.kt
@@ -9,6 +9,20 @@ public inline fun <reified X> Result<*, *>.getAs() = when (this) {
     is Result.Failure -> error as? X
 }
 
+public inline fun <V : Any> Result<V, *>.success(f: (V) -> Unit) {
+    when (this) {
+        is Result.Success -> f(value)
+        is Result.Failure -> {}
+    }
+}
+
+public inline fun <E : Exception> Result<*, E>.failure(f: (E) -> Unit) {
+    when (this) {
+        is Result.Success -> {}
+        is Result.Failure -> f(error)
+    }
+}
+
 public infix fun <V : Any, E : Exception> Result<V, E>.or(fallback: V) = when (this) {
     is Result.Success -> this
     else -> Result.Success<V, E>(fallback)
@@ -33,7 +47,6 @@ public fun <V : Any, E : Exception, E2 : Exception> Result<V, E>.flatMapError(tr
     is Result.Success -> Result.Success<V, E2>(value)
     is Result.Failure -> transform(error)
 }
-
 
 sealed public class Result<out V : Any, out E : Exception> {
 
@@ -62,7 +75,6 @@ sealed public class Result<out V : Any, out E : Exception> {
             return other is Success<*, *> && value == other.value
         }
     }
-
 
     public class Failure<out V : Any, out E : Exception>(val error: E) : Result<V, E>() {
         override fun component1(): V? = null
@@ -96,4 +108,5 @@ sealed public class Result<out V : Any, out E : Exception> {
             Failure(ex)
         }
     }
+
 }


### PR DESCRIPTION
In practice,  sometimes I need one-time check for either success or failure. Before, only way to do it is to use `fold` with one leg ignored. This seems like a workaround. So I added `success` and `failure` to `Result`.

`Result<V, *>.success(f: (V) -> Unit)` and counterpart `Result<*, E>.failure(f: (E) -> Unit)` were added to perform one-off operation upon given block if Result is `success` or `failure`. Otherwise, nothing is happened.