### PR TITLE
Add fanout to Result

### DIFF
--- a/result/src/main/kotlin/com/github/kittinunf/result/Result.kt
+++ b/result/src/main/kotlin/com/github/kittinunf/result/Result.kt
@@ -44,6 +44,9 @@ fun <V : Any> Result<V, *>.any(predicate: (V) -> Boolean): Boolean = when (this)
     is Result.Failure -> false
 }
 
+fun <V : Any, U: Any> Result<V, *>.fanout(other: () -> Result<U, *>): Result<Pair<V, U>, *> =
+    flatMap { outer -> other().map { outer to it } }
+
 sealed class Result<out V : Any, out E : Exception> {
 
     abstract operator fun component1(): V?

--- a/result/src/test/kotlin/com/github/kittinunf/result/ResultTests.kt
+++ b/result/src/test/kotlin/com/github/kittinunf/result/ResultTests.kt
@@ -260,6 +260,20 @@ class ResultTests {
         assertThat("r is Result.Success type", r is Result.Success, isEqualTo(true))
     }
 
+    @Test
+    fun testFanoutSuccesses() {
+        val readFooResult = resultReadFromAssetFileName("foo.txt")
+        val readBarResult = resultReadFromAssetFileName("bar.txt")
+
+        val finalResult = readFooResult.fanout { readBarResult }
+        val (v, e) = finalResult
+
+        assertThat("finalResult is success", finalResult is Result.Success, isEqualTo(true))
+        assertThat("finalResult has a pair type when both are successes", v is Pair<String, String>, isEqualTo(true))
+        assertThat("value of finalResult has text from foo as left and text from bar as right",
+            v!!.first.startsWith("Lorem Ipsum is simply dummy text") && v!!.second.startsWith("Contrary to popular belief"), isEqualTo(true))
+    }
+
     // helper
     fun readFromAssetFileName(name: String): String {
         val dir = System.getProperty("user.dir")

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,2 +1,3 @@
-include ':result'
+rootProject.name = 'result-root'
 
+include ':result'


### PR DESCRIPTION
### What's in this PR?

I am adding `fanout` into `Result` to help deal with situation where you want to combine success value from 2 Results together. The end result is a Result that contains pair of them by the order of the result that put into combining process.

The signature of `fanout` is 

``` Kotlin
fun <V : Any, U: Any> Result<V, *>.fanout(other: () -> Result<U, *>): Result<Pair<V, U>, *>
```