### PR TITLE
Add feature for map/flatMap that throws

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ allprojects {
     ext {
         publish_version = '1.2.0'
 
-        kotlin_version = '1.1.4-3'
+        kotlin_version = '1.2.10'
 
         junit = '4.12'
 

--- a/result/src/main/kotlin/com/github/kittinunf/result/Result.kt
+++ b/result/src/main/kotlin/com/github/kittinunf/result/Result.kt
@@ -11,7 +11,7 @@ fun <E : Exception> Result<*, E>.failure(f: (E) -> Unit) = fold({}, f)
 
 infix fun <V : Any, E : Exception> Result<V, E>.or(fallback: V) = when (this) {
     is Result.Success -> this
-    else -> Result.Success<V, E>(fallback)
+    else -> Result.Success(fallback)
 }
 
 infix fun <V : Any, E : Exception> Result<V, E>.getOrElse(fallback: V) = when (this) {
@@ -20,13 +20,13 @@ infix fun <V : Any, E : Exception> Result<V, E>.getOrElse(fallback: V) = when (t
 }
 
 fun <V : Any, U : Any, E : Exception> Result<V, E>.map(transform: (V) -> U): Result<U, E> = when (this) {
-    is Result.Success -> Result.Success<U, E>(transform(value))
-    is Result.Failure -> Result.Failure<U, E>(error)
+    is Result.Success -> Result.Success(transform(value))
+    is Result.Failure -> Result.Failure(error)
 }
 
 fun <V : Any, U : Any, E : Exception> Result<V, E>.flatMap(transform: (V) -> Result<U, E>): Result<U, E> = when (this) {
     is Result.Success -> transform(value)
-    is Result.Failure -> Result.Failure<U, E>(error)
+    is Result.Failure -> Result.Failure(error)
 }
 
 fun <V : Any, E : Exception, E2 : Exception> Result<V, E>.mapError(transform: (E) -> E2) = when (this) {
@@ -35,7 +35,7 @@ fun <V : Any, E : Exception, E2 : Exception> Result<V, E>.mapError(transform: (E
 }
 
 fun <V : Any, E : Exception, E2 : Exception> Result<V, E>.flatMapError(transform: (E) -> Result<V, E2>) = when (this) {
-    is Result.Success -> Result.Success<V, E2>(value)
+    is Result.Success -> Result.Success(value)
     is Result.Failure -> transform(error)
 }
 
@@ -99,9 +99,8 @@ sealed class Result<out V : Any, out E : Exception> {
         // Factory methods
         fun <E : Exception> error(ex: E) = Failure<Nothing, E>(ex)
 
-        fun <V : Any> of(value: V?, fail: (() -> Exception) = { Exception() }): Result<V, Exception> {
-            return value?.let { Success<V, Nothing>(it) } ?: error(fail())
-        }
+        fun <V : Any> of(value: V?, fail: (() -> Exception) = { Exception() }): Result<V, Exception> =
+                value?.let { Success<V, Nothing>(it) } ?: error(fail())
 
         fun <V : Any> of(f: () -> V): Result<V, Exception> = try {
             Success(f())

--- a/result/src/main/kotlin/com/github/kittinunf/result/Result.kt
+++ b/result/src/main/kotlin/com/github/kittinunf/result/Result.kt
@@ -60,11 +60,9 @@ sealed class Result<out V : Any, out E : Exception> {
     abstract operator fun component1(): V?
     abstract operator fun component2(): E?
 
-    inline fun <X> fold(success: (V) -> X, failure: (E) -> X): X {
-        return when (this) {
-            is Success -> success(this.value)
-            is Failure -> failure(this.error)
-        }
+    inline fun <X> fold(success: (V) -> X, failure: (E) -> X): X = when (this) {
+        is Success -> success(this.value)
+        is Failure -> failure(this.error)
     }
 
     abstract fun get(): V

--- a/result/src/test/kotlin/com/github/kittinunf/result/ResultTests.kt
+++ b/result/src/test/kotlin/com/github/kittinunf/result/ResultTests.kt
@@ -161,9 +161,7 @@ class ResultTests {
     }
 
     //helper
-    fun Nothing.count() = 0
-
-    fun Nothing.getMessage() = ""
+    private fun Nothing.count() = 0
 
     @Test
     fun map() {
@@ -274,7 +272,7 @@ class ResultTests {
         assertThat("finalResult is success", finalResult, instanceOf(Result.Success::class.java))
         assertThat("finalResult has a pair type when both are successes", v is Pair<String, String>, equalTo(true))
         assertThat("value of finalResult has text from foo as left and text from bar as right",
-                v!!.first.startsWith("Lorem Ipsum is simply dummy text") && v!!.second.startsWith("Contrary to popular belief"), equalTo(true))
+                v!!.first.startsWith("Lorem Ipsum is simply dummy text") && v.second.startsWith("Contrary to popular belief"), equalTo(true))
         assertThat("value of the second component is null", e, nullValue())
     }
 

--- a/result/src/test/kotlin/com/github/kittinunf/result/ResultTests.kt
+++ b/result/src/test/kotlin/com/github/kittinunf/result/ResultTests.kt
@@ -2,7 +2,9 @@ package com.github.kittinunf.result
 
 import org.hamcrest.CoreMatchers.notNullValue
 import org.hamcrest.CoreMatchers.nullValue
-import org.junit.Assert.*
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertThat
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import java.io.File
 import java.io.FileNotFoundException
@@ -11,7 +13,7 @@ import org.hamcrest.CoreMatchers.`is` as isEqualTo
 class ResultTests {
 
     @Test
-    fun testCreateValue() {
+    fun createValue() {
         val v = Result.of(1)
 
         assertThat("Result is created successfully", v, notNullValue())
@@ -19,7 +21,7 @@ class ResultTests {
     }
 
     @Test
-    fun testCreateError() {
+    fun createError() {
         val e = Result.error(RuntimeException())
 
         assertThat("Result is created successfully", e, notNullValue())
@@ -27,7 +29,7 @@ class ResultTests {
     }
 
     @Test
-    fun testCreateOptionalValue() {
+    fun createOptionalValue() {
         val value1: String? = null
         val value2: String? = "1"
 
@@ -39,7 +41,7 @@ class ResultTests {
     }
 
     @Test
-    fun testCreateFromLambda() {
+    fun createFromLambda() {
         val f1 = { "foo" }
         val f2 = {
             val v = arrayListOf<Int>()
@@ -62,7 +64,7 @@ class ResultTests {
     }
 
     @Test
-    fun testOr() {
+    fun or() {
         val one = Result.of<Int>(null) or 1
 
         assertThat("one is Result.Success type", one is Result.Success, isEqualTo(true))
@@ -70,14 +72,14 @@ class ResultTests {
     }
 
     @Test
-    fun testOrElse() {
+    fun orElse() {
         val one = Result.of<Int>(null) getOrElse 1
 
         assertThat("one is 1", one, isEqualTo(1))
     }
 
     @Test
-    fun testSuccess() {
+    fun success() {
         val result = Result.of { true }
 
         var beingCalled = false
@@ -95,7 +97,7 @@ class ResultTests {
     }
 
     @Test
-    fun testFailure() {
+    fun failure() {
         val result = Result.of { File("not_found_file").readText() }
 
         var beingCalled = false
@@ -113,7 +115,7 @@ class ResultTests {
     }
 
     @Test
-    fun testGet() {
+    fun get() {
         val f1 = { true }
         val f2 = { File("not_found_file").readText() }
 
@@ -125,7 +127,7 @@ class ResultTests {
         var result = false
         try {
             result2.get()
-        } catch(e: FileNotFoundException) {
+        } catch (e: FileNotFoundException) {
             result = true
         }
 
@@ -134,7 +136,7 @@ class ResultTests {
 
     @Suppress("UNUSED_VARIABLE")
     @Test
-    fun testGetAsValue() {
+    fun getAsValue() {
         val result1 = Result.of(22)
         val result2 = Result.error(KotlinNullPointerException())
 
@@ -146,7 +148,7 @@ class ResultTests {
     }
 
     @Test
-    fun testFold() {
+    fun fold() {
         val success = Result.of("success")
         val failure = Result.error(RuntimeException("failure"))
 
@@ -163,7 +165,7 @@ class ResultTests {
     fun Nothing.getMessage() = ""
 
     @Test
-    fun testMap() {
+    fun map() {
         val success = Result.of("success")
         val failure = Result.error(RuntimeException("failure"))
 
@@ -175,7 +177,7 @@ class ResultTests {
     }
 
     @Test
-    fun testFlatMap() {
+    fun flatMap() {
         val success = Result.of("success")
         val failure = Result.error(RuntimeException("failure"))
 
@@ -187,7 +189,7 @@ class ResultTests {
     }
 
     @Test
-    fun testMapError() {
+    fun mapError() {
         val success = Result.of("success")
         val failure = Result.error(Exception("failure"))
 
@@ -201,7 +203,7 @@ class ResultTests {
     }
 
     @Test
-    fun testFlatMapError() {
+    fun flatMapError() {
         val success = Result.of("success")
         val failure = Result.error(Exception("failure"))
 
@@ -216,7 +218,7 @@ class ResultTests {
     }
 
     @Test
-    fun testAny() {
+    fun any() {
         val foo = Result.of { readFromAssetFileName("foo.txt") }
         val fooo = Result.of { readFromAssetFileName("fooo.txt") }
 
@@ -230,7 +232,7 @@ class ResultTests {
     }
 
     @Test
-    fun testComposableFunctions1() {
+    fun composableFunctions1() {
         val foo = { readFromAssetFileName("foo.txt") }
         val bar = { readFromAssetFileName("bar.txt") }
 
@@ -246,7 +248,7 @@ class ResultTests {
     }
 
     @Test
-    fun testComposableFunctions2() {
+    fun composableFunctions2() {
         val r1 = Result.of(functionThatCanReturnNull(false)).flatMap { resultReadFromAssetFileName("bar.txt") }.mapError { Exception("this should not happen") }
         val r2 = Result.of(functionThatCanReturnNull(true)).map { it.rangeTo(Int.MAX_VALUE) }.mapError { KotlinNullPointerException() }
 
@@ -255,13 +257,13 @@ class ResultTests {
     }
 
     @Test
-    fun testNoException() {
+    fun noException() {
         val r = concat("1", "2")
         assertThat("r is Result.Success type", r is Result.Success, isEqualTo(true))
     }
 
     @Test
-    fun testFanoutSuccesses() {
+    fun fanoutSuccesses() {
         val readFooResult = resultReadFromAssetFileName("foo.txt")
         val readBarResult = resultReadFromAssetFileName("bar.txt")
 
@@ -271,7 +273,12 @@ class ResultTests {
         assertThat("finalResult is success", finalResult is Result.Success, isEqualTo(true))
         assertThat("finalResult has a pair type when both are successes", v is Pair<String, String>, isEqualTo(true))
         assertThat("value of finalResult has text from foo as left and text from bar as right",
-            v!!.first.startsWith("Lorem Ipsum is simply dummy text") && v!!.second.startsWith("Contrary to popular belief"), isEqualTo(true))
+                v!!.first.startsWith("Lorem Ipsum is simply dummy text") && v!!.second.startsWith("Contrary to popular belief"), isEqualTo(true))
+    }
+
+    @Test
+    fun mapThatThrows() {
+
     }
 
     // helper
@@ -289,5 +296,6 @@ class ResultTests {
     fun functionThatCanReturnNull(nullEnabled: Boolean): Int? = if (nullEnabled) null else Int.MIN_VALUE
 
     fun concat(a: String, b: String): Result<String, NoException> = Result.Success(a + b)
+
 
 }

--- a/result/src/test/kotlin/com/github/kittinunf/result/ResultTests.kt
+++ b/result/src/test/kotlin/com/github/kittinunf/result/ResultTests.kt
@@ -1,5 +1,7 @@
 package com.github.kittinunf.result
 
+import org.hamcrest.CoreMatchers.equalTo
+import org.hamcrest.CoreMatchers.instanceOf
 import org.hamcrest.CoreMatchers.notNullValue
 import org.hamcrest.CoreMatchers.nullValue
 import org.junit.Assert.assertFalse
@@ -8,7 +10,6 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 import java.io.File
 import java.io.FileNotFoundException
-import org.hamcrest.CoreMatchers.`is` as isEqualTo
 
 class ResultTests {
 
@@ -17,7 +18,7 @@ class ResultTests {
         val v = Result.of(1)
 
         assertThat("Result is created successfully", v, notNullValue())
-        assertThat("v is Result.Success type", v is Result.Success, isEqualTo(true))
+        assertThat("v is Result.Success type", v, instanceOf(Result.Success::class.java))
     }
 
     @Test
@@ -25,7 +26,7 @@ class ResultTests {
         val e = Result.error(RuntimeException())
 
         assertThat("Result is created successfully", e, notNullValue())
-        assertThat("e is Result.Failure type", e is Result.Failure, isEqualTo(true))
+        assertThat("e is Result.Failure type", e, instanceOf(Result.Failure::class.java))
     }
 
     @Test
@@ -36,8 +37,8 @@ class ResultTests {
         val result1 = Result.of(value1) { UnsupportedOperationException("value is null") }
         val result2 = Result.of(value2) { IllegalStateException("value is null") }
 
-        assertThat("result1 is Result.Failure type", result1 is Result.Failure, isEqualTo(true))
-        assertThat("result2 is Result.Success type", result2 is Result.Success, isEqualTo(true))
+        assertThat("result1 is Result.Failure type", result1, instanceOf(Result.Failure::class.java))
+        assertThat("result2 is Result.Success type", result2, instanceOf(Result.Success::class.java))
     }
 
     @Test
@@ -58,24 +59,24 @@ class ResultTests {
         val result2 = Result.of(f2)
         val result3 = Result.of(f3())
 
-        assertThat("result1 is Result.Success type", result1 is Result.Success, isEqualTo(true))
-        assertThat("result2 is Result.Failure type", result2 is Result.Failure, isEqualTo(true))
-        assertThat("result3 is Result.Failure type", result3 is Result.Failure, isEqualTo(true))
+        assertThat("result1 is Result.Success type", result1, instanceOf(Result.Success::class.java))
+        assertThat("result2 is Result.Failure type", result2, instanceOf(Result.Failure::class.java))
+        assertThat("result3 is Result.Failure type", result3, instanceOf(Result.Failure::class.java))
     }
 
     @Test
     fun or() {
         val one = Result.of<Int>(null) or 1
 
-        assertThat("one is Result.Success type", one is Result.Success, isEqualTo(true))
-        assertThat("value one is 1", one.component1()!!, isEqualTo(1))
+        assertThat("one is Result.Success type", one, instanceOf(Result.Success::class.java))
+        assertThat("value one is 1", one.component1()!!, equalTo(1))
     }
 
     @Test
     fun orElse() {
         val one = Result.of<Int>(null) getOrElse 1
 
-        assertThat("one is 1", one, isEqualTo(1))
+        assertThat("one is 1", one, equalTo(1))
     }
 
     @Test
@@ -92,8 +93,8 @@ class ResultTests {
             notBeingCalled = false
         }
 
-        assertThat(beingCalled, isEqualTo(true))
-        assertThat(notBeingCalled, isEqualTo(true))
+        assertThat(beingCalled, equalTo(true))
+        assertThat(notBeingCalled, equalTo(true))
     }
 
     @Test
@@ -110,8 +111,8 @@ class ResultTests {
             notBeingCalled = false
         }
 
-        assertThat(beingCalled, isEqualTo(true))
-        assertThat(notBeingCalled, isEqualTo(true))
+        assertThat(beingCalled, equalTo(true))
+        assertThat(notBeingCalled, equalTo(true))
     }
 
     @Test
@@ -122,7 +123,7 @@ class ResultTests {
         val result1 = Result.of(f1)
         val result2 = Result.of(f2)
 
-        assertThat("result1 is true", result1.get(), isEqualTo(true))
+        assertThat("result1 is true", result1.get(), equalTo(true))
 
         var result = false
         try {
@@ -131,7 +132,7 @@ class ResultTests {
             result = true
         }
 
-        assertThat("result2 expecting to throw FileNotFoundException", result, isEqualTo(true))
+        assertThat("result2 expecting to throw FileNotFoundException", result, equalTo(true))
     }
 
     @Suppress("UNUSED_VARIABLE")
@@ -143,8 +144,8 @@ class ResultTests {
         val v1: Int = result1.getAs()!!
         val (v2, err) = result2
 
-        assertThat("v1 is equal 22", v1, isEqualTo(22))
-        assertThat("err is KotlinNullPointerException type", err is KotlinNullPointerException, isEqualTo(true))
+        assertThat("v1 is equal 22", v1, equalTo(22))
+        assertThat("err is KotlinNullPointerException type", err is KotlinNullPointerException, equalTo(true))
     }
 
     @Test
@@ -155,8 +156,8 @@ class ResultTests {
         val v1 = success.fold({ 1 }, { 0 })
         val v2 = failure.fold({ 1 }, { 0 })
 
-        assertThat("v1 is equal 1", v1, isEqualTo(1))
-        assertThat("v2 is equal 1", v2, isEqualTo(0))
+        assertThat("v1 is equal 1", v1, equalTo(1))
+        assertThat("v2 is equal 1", v2, equalTo(0))
     }
 
     //helper
@@ -172,7 +173,7 @@ class ResultTests {
         val v1 = success.map { it.count() }
         val v2 = failure.map { it.count() }
 
-        assertThat("v1 getAsInt equals 7", v1.getAs(), isEqualTo(7))
+        assertThat("v1 getAsInt equals 7", v1.getAs(), equalTo(7))
         assertThat("v2 getAsInt null", v2.getAs<Int>(), nullValue())
     }
 
@@ -184,7 +185,7 @@ class ResultTests {
         val v1 = success.flatMap { Result.of(it.last()) }
         val v2 = failure.flatMap { Result.of(it.count()) }
 
-        assertThat("v1 getAsChar equals s", v1.getAs(), isEqualTo('s'))
+        assertThat("v1 getAsChar equals s", v1.getAs(), equalTo('s'))
         assertThat("v2 getAsInt null", v2.getAs<Int>(), nullValue())
     }
 
@@ -196,10 +197,10 @@ class ResultTests {
         val v1 = success.mapError { InstantiationException(it.message) }
         val v2 = failure.mapError { InstantiationException(it.message) }
 
-        assertThat("v1 is success", v1 is Result.Success, isEqualTo(true))
-        assertThat("v1 is success", v1.component1(), isEqualTo("success"))
-        assertThat("v2 is failure", v2 is Result.Failure, isEqualTo(true))
-        assertThat("v2 is failure", v2.component2()!!.message, isEqualTo("failure"))
+        assertThat("v1 is success", v1, instanceOf(Result.Success::class.java))
+        assertThat("v1 is success", v1.component1(), equalTo("success"))
+        assertThat("v2 is failure", v2, instanceOf(Result.Failure::class.java))
+        assertThat("v2 is failure", v2.component2()!!.message, equalTo("failure"))
     }
 
     @Test
@@ -211,10 +212,10 @@ class ResultTests {
         val v2 = failure.flatMapError { Result.error(IllegalArgumentException()) }
 
 
-        assertThat("v1 is success", v1 is Result.Success, isEqualTo(true))
-        assertThat("v1 is success", v1.getAs(), isEqualTo("success"))
-        assertThat("v2 is failure", v2 is Result.Failure, isEqualTo(true))
-        assertThat("v2 is failure", v2.component2() is IllegalArgumentException, isEqualTo(true))
+        assertThat("v1 is success", v1, instanceOf(Result.Success::class.java))
+        assertThat("v1 is success", v1.getAs(), equalTo("success"))
+        assertThat("v2 is failure", v2, instanceOf(Result.Failure::class.java))
+        assertThat("v2 is failure", v2.component2() is IllegalArgumentException, equalTo(true))
     }
 
     @Test
@@ -241,10 +242,10 @@ class ResultTests {
         val (value1, error1) = Result.of(foo).map { it.count() }.mapError { IllegalStateException() }
         val (value2, error2) = Result.of(notFound).map { bar }.mapError { IllegalStateException() }
 
-        assertThat("value1 is 574", value1, isEqualTo(574))
+        assertThat("value1 is 574", value1, equalTo(574))
         assertThat("error1 is null", error1, nullValue())
         assertThat("value2 is null", value2, nullValue())
-        assertThat("error2 is Exception", error2 is IllegalStateException, isEqualTo(true))
+        assertThat("error2 is Exception", error2 is IllegalStateException, equalTo(true))
     }
 
     @Test
@@ -252,14 +253,14 @@ class ResultTests {
         val r1 = Result.of(functionThatCanReturnNull(false)).flatMap { resultReadFromAssetFileName("bar.txt") }.mapError { Exception("this should not happen") }
         val r2 = Result.of(functionThatCanReturnNull(true)).map { it.rangeTo(Int.MAX_VALUE) }.mapError { KotlinNullPointerException() }
 
-        assertThat("r1 is Result.Success type", r1 is Result.Success, isEqualTo(true))
-        assertThat("r2 is Result.Failure type", r2 is Result.Failure, isEqualTo(true))
+        assertThat("r1 is Result.Success type", r1, instanceOf(Result.Success::class.java))
+        assertThat("r2 is Result.Failure type", r2, instanceOf(Result.Failure::class.java))
     }
 
     @Test
     fun noException() {
         val r = concat("1", "2")
-        assertThat("r is Result.Success type", r is Result.Success, isEqualTo(true))
+        assertThat("r is Result.Success type", r, instanceOf(Result.Success::class.java))
     }
 
     @Test
@@ -270,32 +271,87 @@ class ResultTests {
         val finalResult = readFooResult.fanout { readBarResult }
         val (v, e) = finalResult
 
-        assertThat("finalResult is success", finalResult is Result.Success, isEqualTo(true))
-        assertThat("finalResult has a pair type when both are successes", v is Pair<String, String>, isEqualTo(true))
+        assertThat("finalResult is success", finalResult, instanceOf(Result.Success::class.java))
+        assertThat("finalResult has a pair type when both are successes", v is Pair<String, String>, equalTo(true))
         assertThat("value of finalResult has text from foo as left and text from bar as right",
-                v!!.first.startsWith("Lorem Ipsum is simply dummy text") && v!!.second.startsWith("Contrary to popular belief"), isEqualTo(true))
+                v!!.first.startsWith("Lorem Ipsum is simply dummy text") && v!!.second.startsWith("Contrary to popular belief"), equalTo(true))
+        assertThat("value of the second component is null", e, nullValue())
+    }
+
+    @Test
+    fun fanoutFailureOnLeft() {
+        val readFoooResult = resultReadFromAssetFileName("fooo.txt")
+        val readBarResult = resultReadFromAssetFileName("bar.txt")
+
+        val finalResult = readFoooResult.fanout { readBarResult }
+        val (v, e) = finalResult
+
+        assertThat("value of the first component is null", v, nullValue())
+        assertThat("finalResult is failure", finalResult, instanceOf(Result.Failure::class.java))
+        assertThat("error is a file not found exception", e, instanceOf(FileNotFoundException::class.java))
+    }
+
+    @Test
+    fun fanoutFailureOnRight() {
+        val readFoooResult = resultReadFromAssetFileName("foo.txt")
+        val readBarResult = resultReadFromAssetFileName("barr.txt")
+
+        val finalResult = readFoooResult.fanout { readBarResult }
+        val (v, e) = finalResult
+
+        assertThat("value of the first component is null", v, nullValue())
+        assertThat("finalResult is failure", finalResult, instanceOf(Result.Failure::class.java))
+        assertThat("error is a file not found exception", e, instanceOf(FileNotFoundException::class.java))
     }
 
     @Test
     fun mapThatThrows() {
+        val result = Result.of(1)
 
+        var isCalled = false
+
+        val newResult = result.map { throws() }
+        newResult.failure { isCalled = true }
+
+        assertThat("newResult is transformed into failure", newResult, instanceOf(Result.Failure::class.java))
+        assertThat("isCalled is being set as true", isCalled, equalTo(true))
+    }
+
+    @Test
+    fun flatMapThatThrows() {
+        val result = Result.of("hello")
+
+        var isCalled = false
+
+        val newResult = result.flatMap { throwsForFlatmap() }
+        newResult.failure { isCalled = true }
+
+        assertThat("newResult is transformed into failure", newResult, instanceOf(Result.Failure::class.java))
+        assertThat("isCalled is being set as true", isCalled, equalTo(true))
     }
 
     // helper
-    fun readFromAssetFileName(name: String): String {
+    private fun readFromAssetFileName(name: String): String {
         val dir = System.getProperty("user.dir")
         val assetsDir = File(dir, "src/test/assets/")
         return File(assetsDir, name).readText()
     }
 
-    fun resultReadFromAssetFileName(name: String): Result<String, Exception> {
+    private fun resultReadFromAssetFileName(name: String): Result<String, Exception> {
         val operation = { readFromAssetFileName(name) }
         return Result.of(operation)
     }
 
-    fun functionThatCanReturnNull(nullEnabled: Boolean): Int? = if (nullEnabled) null else Int.MIN_VALUE
+    private fun functionThatCanReturnNull(nullEnabled: Boolean): Int? = if (nullEnabled) null else Int.MIN_VALUE
 
-    fun concat(a: String, b: String): Result<String, NoException> = Result.Success(a + b)
+    private fun concat(a: String, b: String): Result<String, NoException> = Result.Success(a + b)
 
+    private fun throws() {
+        throw Exception()
+    }
 
+    private fun throwsForFlatmap(): Result<Int, Exception> {
+        throws()
+        return Result.of(1)
+    }
 }

--- a/result/src/test/kotlin/com/github/kittinunf/result/ValidationTests.kt
+++ b/result/src/test/kotlin/com/github/kittinunf/result/ValidationTests.kt
@@ -14,7 +14,7 @@ class ValidationTests {
 
         val validation = Validation(r1, r2, r3)
         assertThat("validation.hasFailures", validation.hasFailure, isEqualTo(false))
-        assertThat("validation.failures", validation.failures, isEqualTo(listOf<Exception>()))
+        assertThat("validation.failures", validation.failures, isEqualTo(listOf()))
     }
 
     @Test


### PR DESCRIPTION
  ### What's in this PR?

This PR aims to resolve #26 so that it is more idiomatic to use Result with a function that can potentially throw. Thanks, an original reporter for this awesome feedback.
  