### PR TITLE
added extra function

### DIFF
--- a/result/src/main/kotlin/com/github/kittinunf/result/Result.kt
+++ b/result/src/main/kotlin/com/github/kittinunf/result/Result.kt
@@ -117,6 +117,12 @@ sealed class Result<out V : Any, out E : Exception> {
         } catch (ex: Exception) {
             Failure(ex as E)
         }
+
+        fun <V : Any, E: Exception>ofCatching(c : (exception:Exception) -> E,f: () -> V): Result<V, E> = try {
+            Result.Success(f())
+        } catch (ex: Exception) {
+            Result.Failure(c(ex) )
+        }
     }
 
 }

--- a/result/src/test/kotlin/com/github/kittinunf/result/ValidationTests.kt
+++ b/result/src/test/kotlin/com/github/kittinunf/result/ValidationTests.kt
@@ -30,4 +30,19 @@ class ValidationTests {
         assertThat("validation.failures", validation.failures.map { it.message }, isEqualTo(listOf<String?>("Not a number", "Division by zero")))
     }
 
+    @Test
+    fun testValidationWithUserException() {
+
+        val r1: Result<Int, UserException> = Result.of { 1 }
+        val r2: Result<Int, UserException> = Result.of { throw Exception("Not a number") }
+        val r3: Result<Int, UserException> = Result.of { 3 }
+        val r4: Result<Int, UserException> = Result.of { throw Exception("Division by zero") }
+
+        val validation = Validation(r1, r2, r3, r4)
+        assertThat("validation.hasFailures", validation.hasFailure, isEqualTo(true))
+        assertThat("validation.failures", validation.failures.map { it.message }, isEqualTo(listOf<String?>("Not a number", "Division by zero")))
+    }
+
+    class UserException : Exception()
 }
+


### PR DESCRIPTION
This is more of a work in progress pr

currently you have a cast (line 118) from `ex as E` which will can throw a ClassCastException

as some many consumers of libs will have a the own error e.g. `MyError()` which may extend Exception

you can not assume that the return type error can always be cast to the error thrown, in the case of it not being castable you need a function to create a `MyError` from Exception

if you agree I can add test cases around this function?  