### PR TITLE
[Improvement] Make Result plays well with type

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Result
 
-[![Kotlin](https://img.shields.io/badge/kotlin-1.3.10-blue.svg)](http://kotlinlang.org) 
+[![Kotlin](https://img.shields.io/badge/kotlin-1.3.21-blue.svg)](http://kotlinlang.org) 
 [![jcenter](https://api.bintray.com/packages/kittinunf/maven/Result/images/download.svg)](https://bintray.com/kittinunf/maven/Result/_latestVersion) 
 [![Build Status](https://travis-ci.org/kittinunf/Result.svg?branch=master)](https://travis-ci.org/kittinunf/Result)
 [![Codecov](https://codecov.io/github/kittinunf/Result/coverage.svg?branch=master)](https://codecov.io/gh/kittinunf/Result)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,32 +28,34 @@ subprojects {
         plugin("jacoco")
     }
 
-    // publishing
-    val sourceSets = project.the<SourceSetContainer>()
-
-    val sourcesJar by tasks.registering(Jar::class) {
-        from(sourceSets["main"].allSource)
-        classifier = "sources"
-    }
-
-    val doc by tasks.creating(Javadoc::class) {
-        isFailOnError = false
-        source = sourceSets["main"].allJava
-    }
-    val javadocJar by tasks.creating(Jar::class) {
-        dependsOn(doc)
-        from(doc)
-
-        classifier = "javadoc"
-    }
-
     val artifactPublish: String by extra
     val artifactGroupId: String by extra
 
     version = artifactPublish
     group = artifactGroupId
 
+    //publishing
     configure<PublishingExtension> {
+
+        val sourceSets = project.the<SourceSetContainer>()
+
+        val sourcesJar by tasks.registering(Jar::class) {
+            from(sourceSets["main"].allSource)
+            classifier = "sources"
+        }
+
+        val javadocJar by tasks.creating(Jar::class) {
+            val doc by tasks.creating(Javadoc::class) {
+                isFailOnError = false
+                source = sourceSets["main"].allJava
+            }
+
+            dependsOn(doc)
+            from(doc)
+
+            classifier = "javadoc"
+        }
+
         publications {
             register(project.name, MavenPublication::class) {
                 from(components["java"])
@@ -62,6 +64,15 @@ subprojects {
                 groupId = artifactGroupId
                 artifactId = project.name
                 version = artifactPublish
+
+                pom {
+                    licenses {
+                        license {
+                            name.set("MIT License")
+                            url.set("http://www.opensource.org/licenses/mit-license.php")
+                        }
+                    }
+                }
             }
         }
     }

--- a/result/src/main/kotlin/com/github/kittinunf/result/Validation.kt
+++ b/result/src/main/kotlin/com/github/kittinunf/result/Validation.kt
@@ -2,8 +2,7 @@ package com.github.kittinunf.result
 
 class Validation<out E : Exception>(vararg resultSequence: Result<*, E>) {
 
-    val failures: List<E> = resultSequence.filterIsInstance<Result.Failure<*, E>>().map { it.getException() }
+    val failures: List<E> = resultSequence.filterIsInstance<Result.Failure<E>>().map { it.getException() }
 
     val hasFailure = failures.isNotEmpty()
-
 }

--- a/result/src/test/kotlin/com/github/kittinunf/result/ResultTests.kt
+++ b/result/src/test/kotlin/com/github/kittinunf/result/ResultTests.kt
@@ -337,6 +337,37 @@ class ResultTests {
         assertThat("isCalled is being set as true", isCalled, equalTo(true))
     }
 
+    @Test
+    fun successIsSubtypeOfResult() {
+        class AlwaysSuccess : GetFoo {
+            override fun foo(): Result<Foo, Exception> = Result.success(Foo)
+        }
+
+        val s = AlwaysSuccess()
+
+        assertThat(s.foo(), instanceOf(Result::class.java))
+        assertThat(s.foo().get(), equalTo(Foo))
+    }
+
+    @Test(expected = IllegalAccessException::class)
+    fun failureIsSubtypeOfResult() {
+        class AlwaysFailure : GetFoo {
+            override fun foo(): Result<Foo, Exception> = Result.error(IllegalAccessException("Can't get foo"))
+        }
+
+        val e = AlwaysFailure()
+
+        assertThat(e.foo(), instanceOf(Result::class.java))
+
+        e.foo().get()
+    }
+
+    object Foo
+
+    interface GetFoo {
+        fun foo(): Result<Foo, Exception>
+    }
+
     // helper
     private fun readFromAssetFileName(name: String): String {
         val dir = System.getProperty("user.dir")


### PR DESCRIPTION
### What's in this PR?

This PR makes the `Success` and `Failure` plays well with `Result<T, E>` so that it could be passing with ease.

Now, Success's type is `Result<T, Nothing>` and Failure's type is `Failure<Nothing, T>` so it makes the compiler satisfied with the type when passing Result object around.