### PR TITLE
inline Result map and flatmap

### DIFF
--- a/result/src/main/kotlin/com/github/kittinunf/result/Result.kt
+++ b/result/src/main/kotlin/com/github/kittinunf/result/Result.kt
@@ -19,7 +19,7 @@ infix fun <V : Any, E : Exception> Result<V, E>.getOrElse(fallback: V) = when (t
     else -> fallback
 }
 
-fun <V : Any, U : Any, E : Exception> Result<V, E>.map(transform: (V) -> U): Result<U, E> = try {
+inline fun <V : Any, U : Any, E : Exception> Result<V, E>.map(transform: (V) -> U): Result<U, E> = try {
     when (this) {
         is Result.Success -> Result.Success(transform(value))
         is Result.Failure -> Result.Failure(error)
@@ -28,7 +28,7 @@ fun <V : Any, U : Any, E : Exception> Result<V, E>.map(transform: (V) -> U): Res
     Result.error(ex as E)
 }
 
-fun <V : Any, U : Any, E : Exception> Result<V, E>.flatMap(transform: (V) -> Result<U, E>): Result<U, E> = try {
+inline fun <V : Any, U : Any, E : Exception> Result<V, E>.flatMap(transform: (V) -> Result<U, E>): Result<U, E> = try {
     when (this) {
         is Result.Success -> transform(value)
         is Result.Failure -> Result.Failure(error)


### PR DESCRIPTION
Changes the `Result` `map` and `flatMap` functions to `inline`.
The rationale for this is that in this way you can have suspending and non-suspending functions in one flow. The `transform` function can be a suspending function when `flatMap` is inlined.
Also notice that these functions are really small and can be actually pretty safely inlined without bloating the code base. Probably this also enables some compiler optimizations which would be added benefit.

I created this PR because this is the functionality lack of which currently prevents us from using this library in our project.

We work with clean architecture and have a lot of use cases (suspending and non suspending) which return a Result. Then we flatMap all the use cases in logical flows like this:
```
connectToDeviceUseCase.execute()
    .flatMap { device -> discoverParametersUseCase.execute(device) }
    .flatMap { parameters -> setupNotificationsUseCase.execute(parameters) }
```
and so on. Now, if `setupNotificationsUseCase.execute()` is a suspending function (and the rest of the use cases are not), you cannot pass it as the `transform` parameter to `flatMap` unless you make `flatMap` `inline`.