### PR TITLE
✨Implemented doOnError method

### DIFF
--- a/result/src/main/kotlin/com/github/kittinunf/result/Result.kt
+++ b/result/src/main/kotlin/com/github/kittinunf/result/Result.kt
@@ -56,7 +56,7 @@ fun <V : Any?, E : Exception, E2 : Exception> Result<V, E>.flatMapError(transfor
     is Result.Failure -> transform(error)
 }
 
-fun <V : Any?, E : Exception> Result<V, E>.doOnError(f: (E) -> Unit) = when(this) {
+inline fun <V : Any?, E : Exception> Result<V, E>.onError(f: (E) -> Unit) = when(this) {
     is Result.Success -> Result.Success(value)
     is Result.Failure -> {
         f(error)

--- a/result/src/main/kotlin/com/github/kittinunf/result/Result.kt
+++ b/result/src/main/kotlin/com/github/kittinunf/result/Result.kt
@@ -56,6 +56,14 @@ fun <V : Any?, E : Exception, E2 : Exception> Result<V, E>.flatMapError(transfor
     is Result.Failure -> transform(error)
 }
 
+fun <V : Any?, E : Exception> Result<V, E>.doOnError(f: (E) -> Unit) = when(this) {
+    is Result.Success -> Result.Success(value)
+    is Result.Failure -> {
+        f(error)
+        this
+    }
+}
+
 fun <V : Any?, E : Exception> Result<V, E>.any(predicate: (V) -> Boolean): Boolean = try {
     when (this) {
         is Result.Success -> predicate(value)

--- a/result/src/test/kotlin/com/github/kittinunf/result/ResultTests.kt
+++ b/result/src/test/kotlin/com/github/kittinunf/result/ResultTests.kt
@@ -232,12 +232,12 @@ class ResultTests {
     }
 
     @Test
-    fun doOnError() {
+    fun onError() {
         val success = Result.of("success")
         val failure = Result.error(Exception("failure"))
 
-        val v1 = success.doOnError { }
-        val v2 = failure.doOnError { }
+        val v1 = success.onError { }
+        val v2 = failure.onError { }
 
         assertThat("v1 is success", v1, instanceOf(Result.Success::class.java))
         assertThat("v2 is failure", v2, instanceOf(Result.Failure::class.java))

--- a/result/src/test/kotlin/com/github/kittinunf/result/ResultTests.kt
+++ b/result/src/test/kotlin/com/github/kittinunf/result/ResultTests.kt
@@ -232,6 +232,18 @@ class ResultTests {
     }
 
     @Test
+    fun doOnError() {
+        val success = Result.of("success")
+        val failure = Result.error(Exception("failure"))
+
+        val v1 = success.doOnError { }
+        val v2 = failure.doOnError { }
+
+        assertThat("v1 is success", v1, instanceOf(Result.Success::class.java))
+        assertThat("v2 is failure", v2, instanceOf(Result.Failure::class.java))
+    }
+
+    @Test
     fun any() {
         val foo = Result.of<String, Exception> { readFromAssetFileName("foo.txt") }
         val fooo = Result.of<String, Exception> { readFromAssetFileName("fooo.txt") }

--- a/result/src/test/kotlin/com/github/kittinunf/result/ResultTests.kt
+++ b/result/src/test/kotlin/com/github/kittinunf/result/ResultTests.kt
@@ -236,11 +236,16 @@ class ResultTests {
         val success = Result.of("success")
         val failure = Result.error(Exception("failure"))
 
-        val v1 = success.onError { }
-        val v2 = failure.onError { }
+        var hasSuccessChanged = false
+        var hasFailureChanged = false
+
+        val v1 = success.onError { hasSuccessChanged = true }
+        val v2 = failure.onError { hasFailureChanged = true }
 
         assertThat("v1 is success", v1, instanceOf(Result.Success::class.java))
         assertThat("v2 is failure", v2, instanceOf(Result.Failure::class.java))
+        assertThat("hasSuccessChanged is false", hasSuccessChanged, equalTo(false))
+        assertThat("hasFailureChanged is true", hasFailureChanged, equalTo(true))
     }
 
     @Test


### PR DESCRIPTION
I've implemented `doOnError` method on Result which is very similar to RxJava [doOnError operator](https://github.com/ReactiveX/RxJava/wiki/Error-Handling-Operators#doonerror).

Example usage:

```kotlin
val num = Result.of<Int, Exception> { "1a".toInt() }
            .doOnError { log.error { "Cannot parse value to Int" } }
            .get()
```