### PR TITLE
:construction_worker: Added new methods and inline methods

### DIFF
--- a/result/build.gradle.kts
+++ b/result/build.gradle.kts
@@ -6,8 +6,10 @@ sourceSets {
 dependencies {
     val junit: String by project
     val kotlinVersion: String by project
+    val coroutines: String by project
 
     implementation(kotlin("stdlib", kotlinVersion))
 
     testImplementation("junit:junit:$junit")
+    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutines")
 }

--- a/result/src/main/kotlin/com/github/kittinunf/result/Factory.kt
+++ b/result/src/main/kotlin/com/github/kittinunf/result/Factory.kt
@@ -1,0 +1,17 @@
+package com.github.kittinunf.result
+
+inline fun <V> runCatching(block: () -> V): Result<V, Exception> {
+    return try {
+        Result.success(block())
+    } catch (e: Exception) {
+        Result.error(e)
+    }
+}
+
+inline infix fun <T, V> T.runCatching(block: T.() -> V): Result<V, Exception> {
+    return try {
+        Result.success(block())
+    } catch (e: Exception) {
+        Result.error(e)
+    }
+}

--- a/result/src/main/kotlin/com/github/kittinunf/result/Result.kt
+++ b/result/src/main/kotlin/com/github/kittinunf/result/Result.kt
@@ -28,13 +28,6 @@ fun <V: Any?, E: Exception> Result<V, E>.getOrNull(): V? {
     }
 }
 
-inline infix fun <V : Any?, E : Exception> Result<V, E>.getExceptionOrElse(fallback: (V) -> E): E {
-    return when (this) {
-        is Result.Success -> fallback(value)
-        is Result.Failure -> error
-    }
-}
-
 fun <V : Any?, E : Exception> Result<V, E>.getExceptionOrNull(): E? {
     return when (this) {
         is Result.Success -> null

--- a/result/src/test/kotlin/com/github/kittinunf/result/FactoryTests.kt
+++ b/result/src/test/kotlin/com/github/kittinunf/result/FactoryTests.kt
@@ -1,10 +1,16 @@
 package com.github.kittinunf.result
 
-import org.hamcrest.CoreMatchers
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.CoreMatchers.instanceOf
 import org.junit.Test
 import org.hamcrest.MatcherAssert.assertThat
+
+val topLevelRunError = runCatching {
+    val v = arrayListOf<Int>()
+    v[1]
+}
+
+val topLevelRunSuccess = runCatching { "foo" }
 
 class FactoryTests {
     @Test
@@ -16,5 +22,11 @@ class FactoryTests {
         val r2 = runCatching { "foo" }
         assertThat("r1 is IndexOutOfBoundsException instance", r1.getExceptionOrNull(), instanceOf(IndexOutOfBoundsException::class.java))
         assertThat("r2 is foo", r2.get(), equalTo("foo"))
+    }
+
+    @Test
+    fun testRunCatchingTopLevel() {
+        assertThat("topLevelRunError is IndexOutOfBoundsException instance", topLevelRunError.getExceptionOrNull(), instanceOf(IndexOutOfBoundsException::class.java))
+        assertThat("topLevelRunSuccess is foo", topLevelRunSuccess.get(), equalTo("foo"))
     }
 }

--- a/result/src/test/kotlin/com/github/kittinunf/result/FactoryTests.kt
+++ b/result/src/test/kotlin/com/github/kittinunf/result/FactoryTests.kt
@@ -1,0 +1,20 @@
+package com.github.kittinunf.result
+
+import org.hamcrest.CoreMatchers
+import org.hamcrest.CoreMatchers.equalTo
+import org.hamcrest.CoreMatchers.instanceOf
+import org.junit.Test
+import org.hamcrest.MatcherAssert.assertThat
+
+class FactoryTests {
+    @Test
+    fun testRunCatching() {
+        val r1 = runCatching {
+            val v = arrayListOf<Int>()
+            v[1]
+        }
+        val r2 = runCatching { "foo" }
+        assertThat("r1 is IndexOutOfBoundsException instance", r1.getExceptionOrNull(), instanceOf(IndexOutOfBoundsException::class.java))
+        assertThat("r2 is foo", r2.get(), equalTo("foo"))
+    }
+}

--- a/result/src/test/kotlin/com/github/kittinunf/result/ResultTests.kt
+++ b/result/src/test/kotlin/com/github/kittinunf/result/ResultTests.kt
@@ -100,21 +100,6 @@ class ResultTests {
     }
 
     @Test
-    fun getExceptionOrElse() {
-        val defaultError = Exception("fallback error")
-        val error = Exception()
-        val errorMessage = Exception("Message")
-        val one = Result.of<Int>(null) { error }.getExceptionOrElse { defaultError }
-        val two = Result.of(2).getExceptionOrElse { defaultError }
-        val three = Result.of<String, Exception>{ throw errorMessage }
-            .getExceptionOrElse { defaultError }
-
-        assertThat("one is error", one, equalTo(error))
-        assertThat("two is default error", two, equalTo(defaultError))
-        assertThat("three is exception message", three, equalTo(errorMessage))
-    }
-
-    @Test
     fun getExceptionOrNull() {
         val defaultError = Exception("fallback error")
         val error = Exception()

--- a/result/src/test/kotlin/com/github/kittinunf/result/ResultTests.kt
+++ b/result/src/test/kotlin/com/github/kittinunf/result/ResultTests.kt
@@ -1,5 +1,7 @@
 package com.github.kittinunf.result
 
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.CoreMatchers.instanceOf
 import org.hamcrest.CoreMatchers.notNullValue
@@ -54,12 +56,18 @@ class ResultTests {
         }
 
         val result1 = Result.of<String, NoException>(f1)
-        val result2 = Result.of<Int, NoException>(f2)
+        val result2 = Result.of<Int, IndexOutOfBoundsException>(f2)
         val result3 = Result.of(f3())
+        val result4 = try {
+            Result.of<Int, NoException>(f2)
+        } catch (ex: IndexOutOfBoundsException) {
+            Result.error(RuntimeException())
+        }
 
         assertThat("result1 is Result.Success type", result1, instanceOf(Result.Success::class.java))
         assertThat("result2 is Result.Failure type", result2, instanceOf(Result.Failure::class.java))
         assertThat("result3 is Result.Failure type", result3, instanceOf(Result.Failure::class.java))
+        assertThat("result4 has RuntimeException", result4.getExceptionOrNull(), instanceOf(RuntimeException::class.java))
     }
 
     @Test
@@ -89,6 +97,36 @@ class ResultTests {
         assertThat("one is 1", one, equalTo(1))
         assertThat("two is 2", two, equalTo(2))
         assertThat("three is exception message", three, equalTo("Message"))
+    }
+
+    @Test
+    fun getExceptionOrElse() {
+        val defaultError = Exception("fallback error")
+        val error = Exception()
+        val errorMessage = Exception("Message")
+        val one = Result.of<Int>(null) { error }.getExceptionOrElse { defaultError }
+        val two = Result.of(2).getExceptionOrElse { defaultError }
+        val three = Result.of<String, Exception>{ throw errorMessage }
+            .getExceptionOrElse { defaultError }
+
+        assertThat("one is error", one, equalTo(error))
+        assertThat("two is default error", two, equalTo(defaultError))
+        assertThat("three is exception message", three, equalTo(errorMessage))
+    }
+
+    @Test
+    fun getExceptionOrNull() {
+        val defaultError = Exception("fallback error")
+        val error = Exception()
+        val errorMessage = Exception("Message")
+        val one = Result.of<Int>(null) { error }.getExceptionOrNull()
+        val two = Result.of(2).getExceptionOrNull()
+        val three = Result.of<String, Exception>{ throw errorMessage }
+            .getExceptionOrNull()
+
+        assertThat("one is error", one, equalTo(error))
+        assertThat("two is null", two, equalTo(null))
+        assertThat("three is exception message", three, equalTo(errorMessage))
     }
 
     @Test
@@ -185,9 +223,40 @@ class ResultTests {
 
         val v1 = success.map { it.count() }
         val v2 = failure.map { it.count() }
+        val v3 = runBlocking { success.map { delay(10) } }
+
 
         assertThat("v1 getAsInt equals 7", v1.getAs(), equalTo(7))
         assertThat("v2 getAsInt null", v2.getAs<Int>(), nullValue())
+        assertThat("v3 get Unit", v3.get(), equalTo(Unit))
+    }
+
+    @Test
+    fun mapEither() {
+        val success = Result.of("success")
+        val failure = Result.error(RuntimeException("failure"))
+
+        val v1 = success.mapEither(
+            success = {
+                it.count()
+            },
+            failure = {
+                IllegalArgumentException()
+            }
+        )
+        val ex = IllegalArgumentException()
+        val v2 = failure.mapEither(
+            success = {
+                1
+            },
+            failure = {
+                ex
+            }
+        )
+
+        assertThat("v1 get equals 7", v1.get(), equalTo(7))
+        assertThat("v2 getOrNull null", v2.getOrNull(), nullValue())
+        assertThat("v2 getExceptionOrNull null", v2.getExceptionOrNull(), equalTo(ex))
     }
 
     @Test
@@ -246,6 +315,23 @@ class ResultTests {
         assertThat("v2 is failure", v2, instanceOf(Result.Failure::class.java))
         assertThat("hasSuccessChanged is false", hasSuccessChanged, equalTo(false))
         assertThat("hasFailureChanged is true", hasFailureChanged, equalTo(true))
+    }
+
+    @Test
+    fun onSuccess() {
+        val success = Result.of("success")
+        val failure = Result.error(Exception("failure"))
+
+        var hasSuccessChanged = false
+        var hasFailureChanged = false
+
+        val v1 = success.onSuccess { hasSuccessChanged = true }
+        val v2 = failure.onSuccess { hasFailureChanged = true }
+
+        assertThat("v1 is success", v1, instanceOf(Result.Success::class.java))
+        assertThat("v2 is failure", v2, instanceOf(Result.Failure::class.java))
+        assertThat("hasSuccessChanged is false", hasSuccessChanged, equalTo(true))
+        assertThat("hasFailureChanged is true", hasFailureChanged, equalTo(false))
     }
 
     @Test


### PR DESCRIPTION
This adds most of the methods and changes we have been using internally and we think really improves the usability of this library and fixes an imo very important bug we ran into a lot at the beginning in production and is not super easy to debug if you are not aware of it: #59 

One nice thing about having all these inline methods it basically means that we do not need a separate coroutines result but that one can work out of the box with coroutines as you can see in the `.map` test I added.

I know this PR adds a lot at once, I am also happy to split it up and I guess it would require a 4.0 release. Let me know what you think @kittinunf .