### PR TITLE
liftResult feature. #80

### DIFF
--- a/result/src/commonMain/kotlin/com/github/kittinunf/result/Result.kt
+++ b/result/src/commonMain/kotlin/com/github/kittinunf/result/Result.kt
@@ -115,11 +115,6 @@ inline fun <V, reified E : Throwable> List<Result<V, E>>.liftResult(fn: (v: List
         acc
     }.let { fn(it.first, it.second) }
 
-inline fun <V, reified E : Throwable> List<Result<V, E>>.liftSuccess(doWithErrors: (e: List<E>) -> Unit): Result<List<V>, E> {
-        doWithErrors(filter { it.isFailure() }.mapNotNull { it.getFailureOrNull() })
-        return filter{ it.isSuccess() }.lift()
-}
-
 inline fun <V, E : Throwable> Result<V, E>.any(predicate: (V) -> Boolean): Boolean = try {
     when (this) {
         is Result.Success -> predicate(value)

--- a/result/src/commonMain/kotlin/com/github/kittinunf/result/Result.kt
+++ b/result/src/commonMain/kotlin/com/github/kittinunf/result/Result.kt
@@ -110,6 +110,11 @@ inline fun <V, reified E : Throwable> List<Result<V, E>>.lift(): Result<List<V>,
         }
     }
 
+inline fun <V, reified E : Throwable> List<Result<V, E>>.liftSuccess(doWithErrors: (e: List<E>) -> Unit): Result<List<V>, E> {
+        doWithErrors(filter { it.isFailure() }.mapNotNull { it.getFailureOrNull() })
+        return filter{ it.isSuccess() }.lift()
+}
+
 inline fun <V, E : Throwable> Result<V, E>.any(predicate: (V) -> Boolean): Boolean = try {
     when (this) {
         is Result.Success -> predicate(value)

--- a/result/src/commonMain/kotlin/com/github/kittinunf/result/Result.kt
+++ b/result/src/commonMain/kotlin/com/github/kittinunf/result/Result.kt
@@ -101,14 +101,14 @@ inline fun <V, U> Result<V, *>.fanout(other: () -> Result<U, *>): Result<Pair<V,
         other().map { outer to it }
     }
 
-inline fun <V, reified E : Throwable> List<Result<V, E>>.lift(): Result<List<V>, E> = liftResult { successes, errors ->
+inline fun <V, reified E : Throwable> List<Result<V, E>>.lift(): Result<List<V>, E> = lift { successes, errors ->
     when (errors.isEmpty()) {
         true -> Result.success(successes)
         else -> Result.failure(errors.first())
     }
 }
 
-inline fun <V, reified E : Throwable> List<Result<V, E>>.liftResult(fn: (v: List<V>, e: List<E>) -> Result<List<V>, E>): Result<List<V>, E> =
+inline fun <V, reified E : Throwable> List<Result<V, E>>.lift(fn: (v: List<V>, e: List<E>) -> Result<List<V>, E>): Result<List<V>, E> =
     fold(Pair<MutableList<V>, MutableList<E>>(mutableListOf(), mutableListOf())) { acc, result ->
         result.success { acc.first.add(it) }
         result.failure { acc.second.add(it) }

--- a/result/src/commonMain/kotlin/com/github/kittinunf/result/Result.kt
+++ b/result/src/commonMain/kotlin/com/github/kittinunf/result/Result.kt
@@ -101,14 +101,19 @@ inline fun <V, U> Result<V, *>.fanout(other: () -> Result<U, *>): Result<Pair<V,
         other().map { outer to it }
     }
 
-inline fun <V, reified E : Throwable> List<Result<V, E>>.lift(): Result<List<V>, E> =
-    fold(Result.success(mutableListOf<V>()) as Result<MutableList<V>, E>) { acc, result ->
-        acc.flatMap { combine ->
-            result.map {
-                combine.apply { add(it) }
-            }
-        }
+inline fun <V, reified E : Throwable> List<Result<V, E>>.lift(): Result<List<V>, E> = liftResult { successes, errors ->
+    when (errors.isEmpty()) {
+        true -> Result.success(successes)
+        else -> Result.failure(errors.first())
     }
+}
+
+inline fun <V, reified E : Throwable> List<Result<V, E>>.liftResult(fn: (v: List<V>, e: List<E>) -> Result<List<V>, E>): Result<List<V>, E> =
+    fold(Pair<MutableList<V>, MutableList<E>>(mutableListOf(), mutableListOf())) { acc, result ->
+        result.success { acc.first.add(it) }
+        result.failure { acc.second.add(it) }
+        acc
+    }.let { fn(it.first, it.second) }
 
 inline fun <V, reified E : Throwable> List<Result<V, E>>.liftSuccess(doWithErrors: (e: List<E>) -> Unit): Result<List<V>, E> {
         doWithErrors(filter { it.isFailure() }.mapNotNull { it.getFailureOrNull() })

--- a/result/src/commonTest/kotlin/com/github/kittinunf/result/ResultTest.kt
+++ b/result/src/commonTest/kotlin/com/github/kittinunf/result/ResultTest.kt
@@ -330,6 +330,69 @@ class ResultTest {
     }
 
     @Test
+    fun `should liftSuccess the result to a list if all items are successful`() {
+        val rs = listOf("lorem_short", "lorem_long").map {
+            Result.of<String, Exception> {
+                readFile(
+                    directory = "src/commonTest/resources/",
+                    fileName = "$it.txt"
+                )
+            }
+        }.liftSuccess {  }
+
+        assertIs<Result.Success<List<String>>>(rs)
+        assertEquals(rs.get()[0], readFile("src/commonTest/resources", "lorem_short.txt"))
+    }
+
+    @Test
+    fun `should liftSuccess the result to a list if any item is failure`() {
+        val rs = listOf("lorem_short", "lorem_long", "not_found").map {
+            Result.of<String, Exception> {
+                readFile(
+                    directory = "src/commonTest/resources/",
+                    fileName = "$it.txt"
+                )
+            }
+        }.liftSuccess {  }
+
+        assertIs<Result.Success<List<String>>>(rs)
+        assertEquals(rs.get()[0], readFile("src/commonTest/resources", "lorem_short.txt"))
+        assertEquals(2, rs.get().size)
+    }
+
+    @Test
+    fun `should liftSuccess invoking doWithError callback when any item is failure`() {
+        var callbackCalled = false
+        val rs = listOf("not_found2", "lorem_short", "lorem_long", "not_found").map {
+            Result.of<String, Exception> {
+                readFile(
+                    directory = "src/commonTest/resources/",
+                    fileName = "$it.txt"
+                )
+            }
+        }.liftSuccess { errorList ->
+            callbackCalled = true
+            assertEquals(2, errorList.size)
+        }
+
+        assertEquals(callbackCalled, true)
+    }
+
+    @Test
+    fun `should liftSuccess into an empty list when all items are failure`() {
+        val rs = listOf("not_found2", "not_found").map {
+            Result.of<String, Exception> {
+                readFile(
+                    directory = "src/commonTest/resources/",
+                    fileName = "$it.txt"
+                )
+            }
+        }.liftSuccess {  }
+
+        assertEquals(0, rs.get().size)
+    }
+
+    @Test
     fun `should return true if predicate in any matches`() {
         val rs = Result.of<String, Throwable> { readFile(directory = "src/commonTest/resources/", fileName = "lorem_short.txt") }
 

--- a/result/src/commonTest/kotlin/com/github/kittinunf/result/ResultTest.kt
+++ b/result/src/commonTest/kotlin/com/github/kittinunf/result/ResultTest.kt
@@ -330,7 +330,7 @@ class ResultTest {
     }
 
     @Test
-    fun `should liftResult success and failures to callback returning success`() {
+    fun `should lift success and failures to callback returning success`() {
         val rs = listOf("lorem_short", "lorem_long", "not_found").map {
             Result.of<String, Exception> {
                 readFile(
@@ -338,7 +338,7 @@ class ResultTest {
                     fileName = "$it.txt"
                 )
             }
-        }.liftResult { successes, errors ->
+        }.lift { successes, errors ->
             assertEquals(2, successes.size)
             assertEquals(1, errors.size)
             Result.success(successes)
@@ -348,7 +348,7 @@ class ResultTest {
     }
 
     @Test
-    fun `should liftResult success and failures to callback returning error`() {
+    fun `should lift success and failures to callback returning error`() {
         val rs = listOf("lorem_short", "lorem_long", "not_found").map {
             Result.of<String, Exception> {
                 readFile(
@@ -356,7 +356,7 @@ class ResultTest {
                     fileName = "$it.txt"
                 )
             }
-        }.liftResult { successes, errors ->
+        }.lift { successes, errors ->
             assertEquals(2, successes.size)
             assertEquals(1, errors.size)
             Result.failure(errors.first())


### PR DESCRIPTION
Added feature requested https://github.com/kittinunf/Result/issues/80

Added extension method liftSuccess to lift List<Result<V>, E> into Result<List<V>, E> where the returned Result is always success and applies a callback function when there are any errors in List<Result>

Thank you for your time and for this awesome project :)