### PR TITLE
:sparkles: [Extension] Create success and failure extension functions

### DIFF
--- a/result/src/commonMain/kotlin/com/github/kittinunf/result/Result.kt
+++ b/result/src/commonMain/kotlin/com/github/kittinunf/result/Result.kt
@@ -3,9 +3,9 @@ package com.github.kittinunf.result
 import com.github.kittinunf.result.Kind.Failure
 import com.github.kittinunf.result.Kind.Success
 
-fun<V: Any> V.success(): Result.Success<V> = Result.success(this)
+fun <V: Any> V.success(): Result.Success<V> = Result.success(this)
 
-fun<E: Throwable> E.failure(): Result.Failure<E> = Result.failure(this)
+fun <E: Throwable> E.failure(): Result.Failure<E> = Result.failure(this)
 
 inline fun <V> Result<V, *>.success(f: (V) -> Unit) = fold(f, {})
 

--- a/result/src/commonMain/kotlin/com/github/kittinunf/result/Result.kt
+++ b/result/src/commonMain/kotlin/com/github/kittinunf/result/Result.kt
@@ -3,6 +3,10 @@ package com.github.kittinunf.result
 import com.github.kittinunf.result.Kind.Failure
 import com.github.kittinunf.result.Kind.Success
 
+fun<V: Any> V.success(): Result.Success<V> = Result.success(this)
+
+fun<E: Throwable> E.failure(): Result.Failure<E> = Result.failure(this)
+
 inline fun <V> Result<V, *>.success(f: (V) -> Unit) = fold(f, {})
 
 inline fun <E : Throwable> Result<*, E>.failure(f: (E) -> Unit) = fold({}, f)

--- a/result/src/commonMain/kotlin/com/github/kittinunf/result/Result.kt
+++ b/result/src/commonMain/kotlin/com/github/kittinunf/result/Result.kt
@@ -3,7 +3,7 @@ package com.github.kittinunf.result
 import com.github.kittinunf.result.Kind.Failure
 import com.github.kittinunf.result.Kind.Success
 
-fun <V: Any> V.success(): Result.Success<V> = Result.success(this)
+fun <V: Any?> V.success(): Result.Success<V> = Result.success(this)
 
 fun <E: Throwable> E.failure(): Result.Failure<E> = Result.failure(this)
 

--- a/result/src/commonTest/kotlin/com/github/kittinunf/result/ResultTest.kt
+++ b/result/src/commonTest/kotlin/com/github/kittinunf/result/ResultTest.kt
@@ -340,4 +340,22 @@ class ResultTest {
 
         assertFalse(rf.any { it == 0 })
     }
+
+    @Test
+    fun `should result in Failure just the same as companion object's function`() {
+        data class TestException(val errorCode: String, val errorMessage: String): Exception(errorMessage)
+
+        val originalFailure = Result.failure(TestException("error_code", "error message"))
+        val extensionFailure = TestException("error_code", "error message").failure()
+
+        assertEquals(originalFailure, extensionFailure)
+    }
+
+    @Test
+    fun `should result in Success just the same as companion object's function`() {
+        val originalSuccess = Result.success("success")
+        val extensionSuccess = "success".success()
+
+        assertEquals(originalSuccess, extensionSuccess)
+    }
 }


### PR DESCRIPTION
### What's in this PR?

This PR adds extension functions for both `Result.success` and `Result.failure` methods. 

### Description

We have been using an inner-company version of these extension functions for a while now and it have been proved massive productive and a lot more readable for converting/encapsulating direct returns, either for objects or exceptions.