### PR TITLE
Change getOrElse failure type

### DIFF
--- a/result/src/commonMain/kotlin/com/github/kittinunf/result/Result.kt
+++ b/result/src/commonMain/kotlin/com/github/kittinunf/result/Result.kt
@@ -40,7 +40,7 @@ fun <V, E : Throwable> Result<V, E>.getFailureOrNull(): E? = when (this) {
     is Result.Failure -> error
 }
 
-inline infix fun <V, E : Exception> Result<V, E>.getOrElse(fallback: (E) -> V): V = when (this) {
+inline infix fun <V, E : Throwable> Result<V, E>.getOrElse(fallback: (E) -> V): V = when (this) {
     is Result.Success -> value
     is Result.Failure -> fallback(error)
 }


### PR DESCRIPTION
Currently, `getOrElse` function is the only one to still be using `Exception` as the failure type. 

This not only diverge from the general `Throwable` usage standard, but doesn't allow objects such as `Result<X, Throwable>` to use this function.

This PR change the function definition from `fun <V, E : Exception>` to `fun <V, E : Throwable>`.