### PR TITLE
Update Github Actions Main Workflow

### DIFF
--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -1,5 +1,4 @@
-name: Main
-
+name: Run Gradle on Main
 on:
   push:
     branches:
@@ -9,45 +8,23 @@ on:
 jobs:
   publish:
     name: Build and publish - SNAPSHOT
-    runs-on: macos-11
+    runs-on: macos-latest
     steps:
-      - name: Check out code
-        uses: actions/checkout@v2
-
-      - name: Setup Java 11
-        uses: actions/setup-java@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-java@v3
         with:
-          distribution: 'adopt'
-          java-version: '11'
-
-      - name: Cache Gradle
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
-
-      - name: Cache Konan
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.konan/caches
-            ~/.konan/dependencies
-            ~/.konan/kotlin-native-prebuilt-macos-*
-          key: ${{ runner.os }}-konan-${{ hashFiles('**/Dependencies.kt') }}
-          restore-keys: |
-            ${{ runner.os }}-konan-
+          distribution: temurin
+          java-version: 17
 
       - name: Publish to MavenCentral
-        run: ./gradlew publishAllPublicationsToSonatypeRepository --max-workers 1
+        uses: gradle/gradle-build-action@v2
         env:
-          SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
-          SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
-          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
-          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+           SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
+           SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
+           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+        with:
+          arguments: publishAllPublicationsToSonatypeRepository --max-workers 1
 
       - name: Upload allTests results
         uses: actions/upload-artifact@v2.2.3

--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup and execute Gradle 'build' task
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: build --stracktrace
+          arguments: build
 
       - name: Upload allTests results
         uses: actions/upload-artifact@v2.2.3

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx2048m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
 org.gradle.parallel=true
 
 kotlin.mpp.stability.nowarn=true


### PR DESCRIPTION
According to https://github.com/marketplace/actions/gradle-build-action, gradle-build-action has more benefit than setup-java for gradle and caching.