### PR TITLE
watchOS arch

### DIFF
--- a/result/build.gradle.kts
+++ b/result/build.gradle.kts
@@ -25,6 +25,8 @@ kotlin {
     jvm()
     iosX64()
     iosArm64()
+    watchosArm64()
+    watchosSimulatorArm64()
 
     @OptIn(ExperimentalWasmDsl::class)
     wasmJs {


### PR DESCRIPTION
error: `could not found watchosArm64 in result`
adding these seems worked in local maven